### PR TITLE
Fix SSL update bug

### DIFF
--- a/lib/serverpilot.sh
+++ b/lib/serverpilot.sh
@@ -381,7 +381,7 @@ function sp_apps_ssl_add {
 # Example: serverpilot apps ssl update $appid force false
 function sp_apps_ssl_update {
   sp_args_check 3 "$@"
-  local response=$(sp_run "apps/$1/ssl" "{\"$2\":\"$3\"}")
+  local response=$(sp_run "apps/$1/ssl" "{\"$2\":$3}")
   sp_data_check "$response"
 }
 


### PR DESCRIPTION
Thank you for writing serverpilot-shell! You've saved our company so much time by allowing us to easily automate ServerPilot app creations and updates.

**Enabling AutoSSL for an app using:**
`serverpilot apps ssl update $appid auto true`

**Returns this error:**
`Error: Invalid argument: auto`

Removing the quotes for these boolean values fixes it.